### PR TITLE
Remove pre commit hooks from post_gen script

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -12,13 +12,3 @@ def remove_dir(path):
 if __name__ == "__main__":
     if "{{ cookiecutter.use_jupyterlab }}" != "y":
         remove_dir("notebooks")
-
-    if "{{ cookiecutter.use_precommit }}" != "y":
-        remove_file(".pre-commit-config.yaml")
-
-    if "{{ cookiecutter.use_precommit }}" == "y":
-        os.system('echo "Initializing Git for pre-commit... \n"')
-        os.system("git init --initial-branch=main")
-        os.system('echo "Installing pre-commit hooks... \n"')
-        os.system("pre-commit install")
-        os.system('echo "Running pre-commit hooks... \n"')


### PR DESCRIPTION
[Bug fix]
- Removed pre-commit hooks from poste_gen_project.py as the option doesnt exist in cookiecutter.json