### PR TITLE
Template hooks and CI fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew install cookiecutter
 Templates can be directly cloned from Github using:
 
 ```bash
-cookiecutter https://github.com/adi-central-ai/cookiecutter-python-template.git --checkout dev
+cookiecutter https://github.com/adi-central-ai/cookiecutter-python-template.git
 ```
 
 The templates will be stored in the folder:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ Cookiecutter template configured with the following:
 python3 -m pip install --user cookiecutter
 ```
 
+You can install it on Mac using the following command in Terminal:
+
+```bash
+brew install cookiecutter
+```
+
+## Configuration using Github
+
 Templates can be directly cloned from Github using:
 
 ```bash
-cookiecutter https://github.com/adi-central-ai/cookiecutter-python-template.git
+cookiecutter https://github.com/adi-central-ai/cookiecutter-python-template.git --checkout dev
 ```
 
 The templates will be stored in the folder:
@@ -40,6 +48,20 @@ cookiecutter cookiecutter-python-template/
 ### Configuration
 
 After the cookiecutter command and template, the cli will ask several question for setting up the project.
+
+```bash
+[1/11] full_name (Central AI): Name of the developer
+[2/11] email (Central.ai@analog.com): E-mail
+[3/11] namespace (): Modules namespace. If not empty (default), the module will be located in the namespace/module_name folder.
+[4/11] module_name (aiproject_python): Module name
+[5/11] python_version (3.12): Python version. Default is set python 3.12
+[6/11] project_folder : Root folder of the python module development (repository)
+[7/11] short_description (Python project of the Central AI team.): Description for the repository
+[8/11] version (0.1.0): Version of the cookiecutter template.
+[9/11] use_jupyterlab (n): If y then a notebooks directory is created for jupyter notebooks
+[10/11] ci_use_cache (n): If y then use ci cache
+[11/11] create_dev_builds (y): if y then dev builds will be created and uploaded to github's repository.
+```
 
 ### Post configuration
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -18,3 +18,12 @@ if __name__ == "__main__":
 
     if "{{ cookiecutter.use_jupyterlab }}" != "n":
         make_dir("notebooks")
+
+    if len("{{ cookiecutter.namespace }}") !=0:
+        make_dir("{{cookiecutter.namespace}}")
+
+    if "{{ cookiecutter.module_name }}" != 0:
+        if len("{{ cookiecutter.namespace }}") != 0:
+            make_dir("{{cookiecutter.namespace}}/{{cookiecutter.module_name}}")
+        else:
+            make_dir("{{cookiecutter.module_name}}")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,6 +9,12 @@ def remove_file(filepath):
 def remove_dir(path):
     os.rmdir(os.path.join(PROJECT_DIRECTORY, path))
 
+def make_dir(path):
+    os.mkdir(os.path.join(PROJECT_DIRECTORY, path))
+
 if __name__ == "__main__":
     if "{{ cookiecutter.use_jupyterlab }}" != "y":
         remove_dir("notebooks")
+
+    if "{{ cookiecutter.use_jupyterlab }}" != "n":
+        make_dir("notebooks")

--- a/poetry.lock
+++ b/poetry.lock
@@ -322,18 +322,18 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "filelock"
-version = "3.16.0"
+version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
-    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.3)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
@@ -605,13 +605,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.4"
+version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.3.4-py3-none-any.whl", hash = "sha256:8b4ba85412f5065dae40aa19feaa02ac2be584c8b14abd70712b5cd11ad80034"},
-    {file = "platformdirs-4.3.4.tar.gz", hash = "sha256:9e8a037c36fe1b1f1b5de4482e60464272cc8dca725e40b568bf2c285f7509cf"},
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [package.extras]
@@ -1026,13 +1026,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.26.4"
+version = "20.26.5"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.4-py3-none-any.whl", hash = "sha256:48f2695d9809277003f30776d155615ffc11328e6a0a8c1f0ec80188d7874a55"},
-    {file = "virtualenv-20.26.4.tar.gz", hash = "sha256:c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c"},
+    {file = "virtualenv-20.26.5-py3-none-any.whl", hash = "sha256:4f3ac17b81fba3ce3bd6f4ead2749a72da5929c01774948e243db9ba41df4ff6"},
+    {file = "virtualenv-20.26.5.tar.gz", hash = "sha256:ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4"},
 ]
 
 [package.dependencies]

--- a/{{cookiecutter.project_folder}}/pyproject.toml
+++ b/{{cookiecutter.project_folder}}/pyproject.toml
@@ -4,7 +4,7 @@ version = "{{ cookiecutter.version }}"
 description = "{{ cookiecutter.short_description }}"
 authors = ["{{ cookiecutter.full_name }} <{{ cookiecutter.email }}>"]
 readme = "README.md"
-packages = [{include =  "{{ cookiecutter.module_name }}" from = "{{ cookiecutter.namespace }}"}]
+packages = [{include =  "{{ cookiecutter.module_name }}", from = "{{ cookiecutter.namespace }}"}]
 
 [tool.poetry.dependencies]
 python = ">={{ cookiecutter.python_version }}, <3.13"

--- a/{{cookiecutter.project_folder}}/pyproject.toml
+++ b/{{cookiecutter.project_folder}}/pyproject.toml
@@ -4,7 +4,7 @@ version = "{{ cookiecutter.version }}"
 description = "{{ cookiecutter.short_description }}"
 authors = ["{{ cookiecutter.full_name }} <{{ cookiecutter.email }}>"]
 readme = "README.md"
-packages = [{include =  "{{ cookiecutter.namespace + '/' + cookiecutter.module_name if cookiecutter.namespace else cookiecutter.module_name }}"}]
+packages = [{include =  "{{ cookiecutter.module_name }}" from = "{{ cookiecutter.namespace }}"}]
 
 [tool.poetry.dependencies]
 python = ">={{ cookiecutter.python_version }}, <3.13"

--- a/{{cookiecutter.project_folder}}/tasks.py
+++ b/{{cookiecutter.project_folder}}/tasks.py
@@ -1,0 +1,41 @@
+from invoke import task
+
+SRC = "."
+TEST_SRC = "tests/"
+
+
+@task
+def showdeps(ctx):
+    print("Current:")
+    ctx.run("poetry show --tree")
+    print("Latest:")
+    ctx.run("poetry show --latest")
+
+
+@task
+def lint(ctx):
+    print("\n-------------------------------")
+
+    ctx.run(f"poetry run ruff check {TEST_SRC}")
+    ctx.run(f"poetry run mypy {TEST_SRC}")
+
+
+@task
+def format(ctx):
+    ctx.run(f"poetry run ruff --fix {TEST_SRC}")
+    ctx.run("poetry run mdformat README.md")
+
+
+@task
+def test(ctx):
+    ctx.run("poetry run pytest -v --cov")
+
+
+@task(pre=[lint, test])
+def build(ctx):
+    ctx.run("poetry build")
+
+
+@task
+def pre_commit(ctx):
+    ctx.run("poetry run pre-commit run")


### PR DESCRIPTION
This branch consists of the following changes

- Additional hooks in post_gen_script.py to create backend, module and notebooks directory for template. The directory structure once the template is created is as follows:
```
.
├── README.md
├── backend
│   └── rag
├── notebooks
├── pyproject.toml
├── tasks.py
└── tests
    └── __init__.py
```

When the template is configured, thenamespace is set to `backend` and the module_name is set to `rag` in this case

- Addition of tasks.py file for CI in {{project_folder}}

- Additions to README.md