### PR TITLE
Update pyproject.toml to create venv locally

### DIFF
--- a/{{cookiecutter.project_folder}}/poetry.toml
+++ b/{{cookiecutter.project_folder}}/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/{{cookiecutter.project_folder}}/pyproject.toml
+++ b/{{cookiecutter.project_folder}}/pyproject.toml
@@ -40,9 +40,6 @@ build-backend = "poetry.core.masonry.api"
 testpaths = "tests"
 python_files = 'tests/*.py'
 
-[tool.poetry]
-virtualenvs.in-project = true
-
 # public pypi packgaes.
 [[tool.poetry.source]]
 name = "PyPI"

--- a/{{cookiecutter.project_folder}}/pyproject.toml
+++ b/{{cookiecutter.project_folder}}/pyproject.toml
@@ -40,6 +40,9 @@ build-backend = "poetry.core.masonry.api"
 testpaths = "tests"
 python_files = 'tests/*.py'
 
+[tool.poetry]
+virtualenvs.in-project = true
+
 # public pypi packgaes.
 [[tool.poetry.source]]
 name = "PyPI"


### PR DESCRIPTION
Feels it make more sense to keep local venv within a project by default verses in a home directory (we exclude assumption that the setting may be (was) changed globally)